### PR TITLE
Test/unit

### DIFF
--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NOTE: Changed the scope of this function in order to test it
 // AnalyseCmd represents the analyse command
 var AnalyseCmd = &cobra.Command{
 	Use:   "analyse <results file>",
@@ -40,13 +39,7 @@ var AnalyseCmd = &cobra.Command{
 	},
 }
 
-/*
-	NOTE: Changed the scope of this function in order to test it
-
-	Also, I commented out the variables op and hostname where initialised in order
-	to test the func. I didn't know how to set the appropriate flags at the time
-	of writing the tests.
-*/
+// AnalyseResults Analyse the output of a Test Suite run
 func AnalyseResults(cmd *cobra.Command, ts *suite.TestSuite, results []result.NetconfResult) {
 
 	log.Println("")
@@ -104,9 +97,8 @@ func AnalyseResults(cmd *cobra.Command, ts *suite.TestSuite, results []result.Ne
 	table.Render()
 }
 
-// NOTE: Changed the scope of this function in order to test it
+// OrderAndExcludeErrValues Orders the results and removes errors from output. Returns number of errors found.
 func OrderAndExcludeErrValues(results []result.NetconfResult, latencies map[string]map[string][]float64) int {
-	SortResults(results)
 
 	var errCount int
 	for _, result := range results {
@@ -120,10 +112,11 @@ func OrderAndExcludeErrValues(results []result.NetconfResult, latencies map[stri
 			latencies[result.Hostname][result.Operation] = append(latencies[result.Hostname][result.Operation], result.Latency)
 		}
 	}
+	SortResults(results)
 	return errCount
 }
 
-// NOTE: Changed the scope of this function in order to test it
+// SortResults Sorts its contents by hostname or operation if duplicate hostnames exist
 func SortResults(results []result.NetconfResult) {
 	sort.Slice(results, func(i, j int) bool {
 		if results[i].Hostname != results[j].Hostname {

--- a/cmd/analyse_test.go
+++ b/cmd/analyse_test.go
@@ -60,7 +60,6 @@ func TestSortResults(t *testing.T) {
 
 		testSort(t, unsortedSlice, want)
 	})
-
 }
 
 func TestOrderAndExcludeErrValues(t *testing.T) {
@@ -76,7 +75,7 @@ func TestOrderAndExcludeErrValues(t *testing.T) {
 
 /*
 	NOTE: In the test function below I am only testing one NetconfResult struct this is due to the problem
-	I mentioned I had in the meeting earlier on today regarding the latencies hashmap. I will try using the
+	I mentioned I had in the meeting earlier on today regarding the latencies hashMap. I will try using the
 	SortResults func after this commit to correct the problem.
 
 	TODO:

--- a/cmd/analyse_test.go
+++ b/cmd/analyse_test.go
@@ -27,11 +27,11 @@ import (
 
 // Test variables used to populate []result.NetconfResult used throughout
 var (
-	ts1 = result.NetconfResult{5, 2318, "172.26.138.91", "edit-config", 55282, "", 288}
-	ts2 = result.NetconfResult{6, 859, "172.26.138.92", "get-config", 55943, "", 176}
-	ts3 = result.NetconfResult{4, 601, "172.26.138.93", "get", 59840, "", 3320}
-	ts4 = result.NetconfResult{4, 2322, "172.26.138.91", "get", 56967, "", 420}
-	ts5 = result.NetconfResult{4, 860, "172.26.138.92", "kill-session", 0, "kill-session is not a supported operation", 0}
+	ts1 = result.NetconfResult{Client: 5, SessionID: 2318, Hostname: "172.26.138.91", Operation: "edit-config", When: 55282, Err: "", Latency: 288}
+	ts2 = result.NetconfResult{Client: 6, SessionID: 859, Hostname: "172.26.138.92", Operation: "get-config", When: 55943, Err: "", Latency: 176}
+	ts3 = result.NetconfResult{Client: 4, SessionID: 601, Hostname: "172.26.138.93", Operation: "get", When: 9840, Err: "", Latency: 3320}
+	ts4 = result.NetconfResult{Client: 4, SessionID: 2322, Hostname: "172.26.138.91", Operation: "get", When: 56967, Err: "", Latency: 420}
+	ts5 = result.NetconfResult{Client: 4, SessionID: 860, Hostname: "172.26.138.92", Operation: "kill-session", When: 0, Err: "kill-session is not a supported operation", Latency: 0}
 )
 
 func TestSortResults(t *testing.T) {
@@ -73,24 +73,10 @@ func TestOrderAndExcludeErrValues(t *testing.T) {
 	}
 }
 
-/*
-	NOTE: In the test function below I am only testing one NetconfResult struct this is due to the problem
-	I mentioned I had in the meeting earlier on today regarding the latencies hashMap. I will try using the
-	SortResults func after this commit to correct the problem.
-
-	TODO:
-	Add test cases to capture op and hostname test cases
-		if op != "" && op != operation {
-			continue
-		}
-		if hostname != "" && hostname != host {
-			continue
-		}
-*/
 func TestAnalyseResults(t *testing.T) {
 
 	var mockCmd *cobra.Command
-	var mockResults = []result.NetconfResult{ts1}
+	var mockResults = []result.NetconfResult{ts1, ts2, ts3}
 	var mockTs = TestSuite{}
 	mockTs.File = "testdata/emptytestsuite.yml"
 
@@ -152,8 +138,9 @@ func TestAnalyseResults(t *testing.T) {
 
 	assert.Equal(t, got, logBuffer.String()) // test
 
-	op := ""
-	hostname := ""
+	// TODO: Add test cases to capture op and hostname test cases --
+	op := ""       // AnalyseCmd.Flags().StringP("operation", "o", "", "filter based on operation type; get, get-config or edit-config")
+	hostname := "" // AnalyseCmd.Flags().StringP("hostname", "", "", "filter based on host name or ip")
 
 	// Build console test string
 
@@ -208,21 +195,6 @@ func TestAnalyseArgs(t *testing.T) {
 		testStruct(t, b, rstr)
 	})
 }
-
-/*
-NOTE:
-Below is the test func which I discussed in the meeting earlier today.
-To test the func I decided I would base my test around which exit status was returned: 0 for success;
-non-0 for failure. Golang doesn’t provide a straightforward way of capturing this, so I had to look online for a solution.
-
-Andrew Gerrand provides a solution to this problem here https://talks.golang.org/2014/testing.slide#23 ,
-and discusses its implementation here https://www.youtube.com/watch?v=ndmB0bj7eyw&feature=youtu.be&t=47m09s
-
-This solution uses a sub-process to examine how the program exits, and then allows you to look at it’s exit status.
-The only downside to this is that as it uses a sub-process to examine how the main test function exits, Go
-doesn’t recognise this subprocess and hence doesn’t count it when checking code coverage. This post explains
-it further: https://stackoverflow.com/questions/40615641/testing-os-exit-scenarios-in-go-with-coverage-information-coveralls-io-goverall
-*/
 
 // TODO: Add further test cases
 func TestAnalyseRun(t *testing.T) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,7 +55,7 @@ var initCmd = &cobra.Command{
 	},
 }
 
-// NOTE: Changed the scope of this function in order to test it
+// BuildTestSuite Initialises a TestSuite struct with default values and returns a pointer to it.
 func BuildTestSuite(path string) *suite.TestSuite {
 	var ts suite.TestSuite
 	ts.Iterations = 5

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -8,9 +8,6 @@ import (
 	. "github.com/nc-hammer/cmd"
 )
 
-/*
-	NOTE: UNFINISHED -- checking for correct initialisation of Testsuite struct
-*/
 func TestBuildTestSuite(t *testing.T) {
 
 	mockPath := ""

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -28,6 +28,6 @@ func TestBuildTestSuite(t *testing.T) {
 		values[i] = got.Field(i).Interface()
 	}
 
-	fmt.Println(values) // printing out fields in struct to test later
+	fmt.Println(values)
 
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -29,6 +30,7 @@ func TestBuildTestSuite(t *testing.T) {
 	for i := 0; i < got.NumField(); i++ {
 		values[i] = got.Field(i).Interface()
 	}
-	//fmt.Println(values) // printing out fields in struct to test later
+
+	fmt.Println(values) // printing out fields in struct to test later
 
 }


### PR DESCRIPTION
Removed excess comments. 

Rearranged the call to sortResults() within func OrderAndExcludeErrValues to ensure correct ordering within latencies Map in analyse.go